### PR TITLE
Progress bar in tqdm is now beeping like NVDA screenreader

### DIFF
--- a/colab_a11y_utils.py
+++ b/colab_a11y_utils.py
@@ -87,10 +87,10 @@ class tqdm(original_tqdm):
         progress_rate = self.n / self.total
         pan = max(min(-1.0 + progress_rate * 2, 1.0), -1.0)
 
-        sound = Triangle(523.23 + progress_rate*523.27).to_audio_segment(duration=100)\
+        sound = Triangle(110*2**(progress_rate)/0.25).to_audio_segment(duration=50)\
             .apply_gain(-10)\
-            .fade_in(20)\
-            .fade_out(20)\
+            .fade_in(5)\
+            .fade_out(5)\
             .pan(pan)
 
         display(InvisibleAudio(data=sound.export().read(), autoplay=True))

--- a/colab_a11y_utils.py
+++ b/colab_a11y_utils.py
@@ -87,7 +87,7 @@ class tqdm(original_tqdm):
         progress_rate = self.n / self.total
         pan = max(min(-1.0 + progress_rate * 2, 1.0), -1.0)
 
-        sound = Triangle(110*2**(progress_rate)/0.25).to_audio_segment(duration=50)\
+        sound = Triangle(110*2**(progress_rate/0.25)).to_audio_segment(duration=50)\
             .apply_gain(-10)\
             .fade_in(5)\
             .fade_out(5)\

--- a/colab_a11y_utils.py
+++ b/colab_a11y_utils.py
@@ -87,7 +87,7 @@ class tqdm(original_tqdm):
         progress_rate = self.n / self.total
         pan = max(min(-1.0 + progress_rate * 2, 1.0), -1.0)
 
-        sound = Triangle(110*2**(progress_rate/0.25)).to_audio_segment(duration=50)\
+        sound = Triangle(110*(2**(progress_rate*4))).to_audio_segment(duration=50)\
             .apply_gain(-10)\
             .fade_in(5)\
             .fade_out(5)\


### PR DESCRIPTION
From now on, the progress bar beeper beeps exactly like NVDA screenreader does! With the same frequencies, with the same notes! People who are used to determin the percentage of windows progress bars with nvda by ear are now able to hear the percentage from colab a11y utils correctly!